### PR TITLE
fix hashicorpurlprovider.

### DIFF
--- a/VagrantVMWareUtility/VagrantVMWareUtility.download.recipe
+++ b/VagrantVMWareUtility/VagrantVMWareUtility.download.recipe
@@ -17,7 +17,7 @@
 	<array>
 		<dict>
 			<key>Processor</key>
-			<string>io.github.hjuutilainen.download.Vault/HashiCorpURLProvider</string>
+			<string>io.github.hjuutilainen.SharedProcessors/HashiCorpURLProvider</string>
 			<key>Arguments</key>
 			<dict>
 				<key>project_name</key>


### PR DESCRIPTION
hashicorpurlprovider location has changed and was getting the error: 
```WARNING: processor path not found for processor: io.github.hjuutilainen.download.Vault/HashiCorpURLProvider```